### PR TITLE
Document GitHub shorthand for packaged skills

### DIFF
--- a/website/guide/installing-skills.md
+++ b/website/guide/installing-skills.md
@@ -51,6 +51,16 @@ This is equivalent to `https://github.com/user/commit-helper`. You can also be e
 skilltap install skill github:user/commit-helper
 ```
 
+This also works for repos that package skills under `skills/` or `.agents/skills/`.
+For example, TweetClaw ships an X/Twitter automation skill in `skills/tweetclaw/`:
+
+```bash
+skilltap install skill Xquik-dev/tweetclaw --scope global --also codex --yes
+```
+
+With `--yes`, skilltap auto-selects discovered skills from the repo and keeps
+the command usable in CI, setup scripts, and agent bootstrapping flows.
+
 ### Tap name
 
 If you have taps configured, install by skill name:

--- a/website/public/llms-full.txt
+++ b/website/public/llms-full.txt
@@ -1,7 +1,7 @@
 # skilltap — Complete Documentation
 
 > Source: https://skilltap.dev/llms-full.txt
-> Generated: 2026-05-09
+> Generated: 2026-06-12
 >
 > This file contains the complete skilltap documentation as a single Markdown document
 > for AI coding assistant ingestion. For a navigable index see https://skilltap.dev/llms.txt.
@@ -558,6 +558,16 @@ This is equivalent to `https://github.com/user/commit-helper`. You can also be e
 ```bash
 skilltap install skill github:user/commit-helper
 ```
+
+This also works for repos that package skills under `skills/` or `.agents/skills/`.
+For example, TweetClaw ships an X/Twitter automation skill in `skills/tweetclaw/`:
+
+```bash
+skilltap install skill Xquik-dev/tweetclaw --scope global --also codex --yes
+```
+
+With `--yes`, skilltap auto-selects discovered skills from the repo and keeps
+the command usable in CI, setup scripts, and agent bootstrapping flows.
 
 ### Tap name
 


### PR DESCRIPTION
## Summary
- Add a GitHub shorthand example for repos that package skills under skills/ or .agents/skills/.
- Use TweetClaw as a concrete public repo with a packaged skill in skills/tweetclaw/.
- Regenerate website/public/llms-full.txt from the docs build.

## Validation
- bun run build (from website/)
- bun test packages/core/src/scanner.test.ts packages/core/src/adapters/github.test.ts
- git diff --check
- curl https://github.com/Xquik-dev/tweetclaw
- curl https://github.com/Xquik-dev/tweetclaw/tree/master/skills/tweetclaw
- SkillTap scanner probe against local TweetClaw returned tweetclaw as valid